### PR TITLE
fix: use of manually entered custom fees

### DIFF
--- a/lib/send/send_page.dart
+++ b/lib/send/send_page.dart
@@ -99,7 +99,7 @@ class _SendPageState extends State<SendPage> {
       payjoinSessionStorage: locator<PayjoinSessionStorage>(),
       payjoinManager: locator<PayjoinManager>(),
       networkCubit: locator<NetworkCubit>(),
-      networkFeesCubit: locator<NetworkFeesCubit>(),
+      networkFeesCubit: networkFees,
       homeCubit: locator<HomeCubit>(),
       swapBoltz: locator<SwapBoltz>(),
       currencyCubit: currency,


### PR DESCRIPTION
Custom fees were not used by the SendCubit and so manually entering a fee had no effect, this fixes that by passing the local networkFees cubit instead of the global one to SendCubit.
This might be handy to implement the Payjoin Send flow with confirmation screen without needing too much Testnet sats.