### PR TITLE
fix: change T to Object and typecast where needed

### DIFF
--- a/lib/_ui/components/controls.dart
+++ b/lib/_ui/components/controls.dart
@@ -14,9 +14,9 @@ class BBSwitcher<T> extends StatelessWidget {
     required this.value,
   });
 
-  final Map<T, String> items;
-  final void Function(T) onChanged;
-  final T value;
+  final Map<Object, String> items;
+  final void Function(Object) onChanged;
+  final Object value;
 
   Widget _buildItem(String title, {bool darkMode = false}) {
     return SizedBox(
@@ -33,8 +33,8 @@ class BBSwitcher<T> extends StatelessWidget {
     );
   }
 
-  Map<T, Widget> _buildItems(bool darkMode) {
-    final map = <T, Widget>{};
+  Map<Object, Widget> _buildItems(bool darkMode) {
+    final map = <Object, Widget>{};
     for (final key in items.keys) {
       map[key] = _buildItem(items[key]!, darkMode: darkMode);
     }
@@ -60,7 +60,7 @@ class BBSwitcher<T> extends StatelessWidget {
         ),
         border: Border.all(color: borderColour),
       ),
-      child: CupertinoSlidingSegmentedControl(
+      child: CupertinoSlidingSegmentedControl<Object>(
         groupValue: value,
         padding: const EdgeInsets.symmetric(vertical: 3, horizontal: 4),
         children: _buildItems(darkMode),

--- a/lib/receive/receive_page.dart
+++ b/lib/receive/receive_page.dart
@@ -346,7 +346,7 @@ class SelectWalletType extends StatelessWidget {
         context.read<CreateSwapCubit>().removeWarnings();
 
         final isTestnet = context.read<NetworkCubit>().state.testnet;
-        context.read<ReceiveCubit>().updateWalletType(value, isTestnet);
+        context.read<ReceiveCubit>().updateWalletType(value as PaymentNetwork, isTestnet);
       },
     );
   }


### PR DESCRIPTION
Had to do this after `flutter upgrade` since the `CupertinoSlidingSegmentedControl` was giving an error:

![signal-2024-12-20-194956_002](https://github.com/user-attachments/assets/b1584b79-4421-45ae-a9e1-d5b9d377b82f)

My version now:

Flutter 3.27.1 • channel stable • https://github.com/flutter/flutter.git
Framework • revision 17025dd882 (4 days ago) • 2024-12-17 03:23:09 +0900
Engine • revision cb4b5fff73
Tools • Dart 3.6.0 • DevTools 2.40.2

And FWIW I was able to run this branch on Android too.